### PR TITLE
Detect wrong driver for silicon + add ST25R300 example

### DIFF
--- a/components/st25r/st25r.cpp
+++ b/components/st25r/st25r.cpp
@@ -966,7 +966,16 @@ bool ST25R::reset_chip() {
   ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
   uint8_t chip_type = ic_identity & 0xF8;
   if (chip_type != 0x28 && chip_type != 0x30) {
-    ESP_LOGE(TAG, "  reset_: IC identity mismatch! Expected 0x28/0x30, got 0x%02X", chip_type);
+    uint8_t sibling = this->probe_sibling_identity_();
+    if ((sibling & 0xF8) == 0xB0) {
+      ESP_LOGE(TAG, "  reset_: Wrong driver! Chip responds to ST25R300 encoding "
+                    "(IC_IDENTITY=0x%02X, rev %u).", sibling, sibling & 0x07);
+      ESP_LOGE(TAG, "  reset_: You have ST25R300 silicon — switch YAML from st25r_spi to st25r300_spi:");
+      ESP_LOGE(TAG, "  reset_:   external_components: ... components: [st25r300, st25r300_spi]");
+      ESP_LOGE(TAG, "  reset_:   st25r300_spi: { cs_pin: ..., irq_pin: ..., reset_pin: ... }");
+    } else {
+      ESP_LOGE(TAG, "  reset_: IC identity mismatch! Expected 0x28/0x30, got 0x%02X", chip_type);
+    }
     return false;
   }
 

--- a/components/st25r/st25r.h
+++ b/components/st25r/st25r.h
@@ -182,6 +182,11 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   virtual void write_fifo(const uint8_t *data, size_t len) = 0;
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
+  // Cross-encoding IC_IDENTITY probe — each SPI backend reads 0x3F using the
+  // OTHER chip family's read encoding. Used on identity-check failure to tell
+  // the user they loaded the wrong driver for their silicon. Default is a no-op.
+  virtual uint8_t probe_sibling_identity_() { return 0xFF; }
+
   // Chip-specific overrides — each uses the ST25R3916 default or can be overridden
   virtual bool reset_chip();
   virtual void reinitialize();

--- a/components/st25r300/st25r300.cpp
+++ b/components/st25r300/st25r300.cpp
@@ -457,8 +457,19 @@ bool ST25R300::reset_chip() {
   uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
   ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
   if ((ic_identity & ST25R300_IC_TYPE_MASK) != ST25R300_IC_TYPE_VAL) {
-    ESP_LOGE(TAG, "  reset_: IC identity mismatch! Expected 0xB0, got chip_type=0x%02X",
-             ic_identity & ST25R300_IC_TYPE_MASK);
+    uint8_t sibling = this->probe_sibling_identity_();
+    uint8_t sib_type = sibling & 0xF8;
+    if (sib_type == 0x28 || sib_type == 0x30) {
+      ESP_LOGE(TAG, "  reset_: Wrong driver! Chip responds to ST25R3916 encoding "
+                    "(IC_IDENTITY=0x%02X).", sibling);
+      ESP_LOGE(TAG, "  reset_: You have ST25R3916%s silicon — switch YAML from st25r300_spi to st25r_spi:",
+               sib_type == 0x30 ? "B" : "");
+      ESP_LOGE(TAG, "  reset_:   external_components: ... components: [st25r, st25r_spi]");
+      ESP_LOGE(TAG, "  reset_:   st25r_spi: { cs_pin: ..., irq_pin: ..., reset_pin: ... }");
+    } else {
+      ESP_LOGE(TAG, "  reset_: IC identity mismatch! Expected 0xB0, got chip_type=0x%02X",
+               ic_identity & ST25R300_IC_TYPE_MASK);
+    }
     return false;
   }
 

--- a/components/st25r300_spi/st25r300_spi.cpp
+++ b/components/st25r300_spi/st25r300_spi.cpp
@@ -56,5 +56,16 @@ void ST25R300Spi::read_fifo(uint8_t *data, size_t len) {
   this->disable();
 }
 
+uint8_t ST25R300Spi::probe_sibling_identity_() {
+  // Read IC_IDENTITY (0x3F) using ST25R3916's read encoding (0x40 | reg).
+  // Called after the ST25R300-encoded identity read fails — if the attached silicon
+  // is actually ST25R3916, this returns a valid chip signature (chip_type 0x28 or 0x30).
+  this->enable();
+  this->write_byte(0x7F);
+  uint8_t value = this->read_byte();
+  this->disable();
+  return value;
+}
+
 }  // namespace st25r300_spi
 }  // namespace esphome

--- a/components/st25r300_spi/st25r300_spi.h
+++ b/components/st25r300_spi/st25r300_spi.h
@@ -27,6 +27,7 @@ class ST25R300Spi : public st25r300::ST25R300,
   void write_command(uint8_t command) override;
   void write_fifo(const uint8_t *data, size_t len) override;
   void read_fifo(uint8_t *data, size_t len) override;
+  uint8_t probe_sibling_identity_() override;
 };
 
 }  // namespace st25r300_spi

--- a/components/st25r_spi/st25r_spi.cpp
+++ b/components/st25r_spi/st25r_spi.cpp
@@ -62,5 +62,16 @@ void ST25RSpi::read_fifo(uint8_t *data, size_t len) {
   this->disable();
 }
 
+uint8_t ST25RSpi::probe_sibling_identity_() {
+  // Read IC_IDENTITY (0x3F) using ST25R300's read encoding (0x80 | reg).
+  // Called after the 3916-encoded identity read fails — if the attached silicon
+  // is actually ST25R300, this returns a valid chip signature (top 5 bits 10110b).
+  this->enable();
+  this->write_byte(0xBF);
+  uint8_t value = this->read_byte();
+  this->disable();
+  return value;
+}
+
 }  // namespace st25r_spi
 }  // namespace esphome

--- a/components/st25r_spi/st25r_spi.h
+++ b/components/st25r_spi/st25r_spi.h
@@ -20,6 +20,7 @@ class ST25RSpi : public st25r::ST25R,
   void write_command(uint8_t command) override;
   void write_fifo(const uint8_t *data, size_t len) override;
   void read_fifo(uint8_t *data, size_t len) override;
+  uint8_t probe_sibling_identity_() override;
 };
 
 }  // namespace st25r_spi

--- a/examples/example-access-control.yaml
+++ b/examples/example-access-control.yaml
@@ -1,5 +1,6 @@
-# Advanced ESPHome configuration for ST25R NFC Reader
+# Advanced ESPHome configuration for ST25R3916/3916B NFC Reader
 # Implementation of an Access Control System
+# For ST25R300 silicon, see example-st25r300.yaml instead.
 
 esphome:
   name: st25r-access-control

--- a/examples/example-basic.yaml
+++ b/examples/example-basic.yaml
@@ -1,4 +1,5 @@
-# Example ESPHome configuration for ST25R NFC Reader
+# Example ESPHome configuration for ST25R3916/3916B NFC Reader.
+# For ST25R300 silicon, see example-st25r300.yaml instead.
 esphome:
   name: st25r-nfc-reader
   friendly_name: ST25R NFC Reader

--- a/examples/example-st25r300.yaml
+++ b/examples/example-st25r300.yaml
@@ -1,0 +1,50 @@
+# Example ESPHome configuration for ST25R300 NFC Reader
+# For ST25R3916/3916B silicon, see example-basic.yaml or example-access-control.yaml.
+esphome:
+  name: st25r300-nfc-reader
+  friendly_name: ST25R300 NFC Reader
+
+esp32:
+  board: esp32-c6-devkitc-1
+  variant: esp32c6
+
+logger:
+  level: DEBUG
+
+wifi:
+  ssid: "ST25R300 Fallback"
+  password: "PASSWORD"
+
+external_components:
+  - source: github://JohnMcLear/esphome_st25r
+    components: [ st25r300, st25r300_spi ]
+
+# Enable SPI bus
+spi:
+  clk_pin: GPIO19
+  mosi_pin: GPIO10
+  miso_pin: GPIO18
+
+# Configure ST25R300 NFC reader via SPI
+st25r300_spi:
+  id: my_st25r300
+  cs_pin: GPIO7
+  irq_pin: GPIO6
+  reset_pin: GPIO5
+  update_interval: 1s
+  rf_field_enabled: true
+  rf_power: 15           # 0..15 (15 = full power)
+  rx_gain_boost: false
+  nfcv_enabled: true     # ISO 15693
+  nfcb_enabled: true     # ISO 14443-B
+  health_check_enabled: true
+  health_check_interval: 60s
+
+  # Tag detection triggers
+  on_tag:
+    - lambda: |-
+        ESP_LOGI("main", "Tag detected: %s", x.c_str());
+
+  on_tag_removed:
+    - lambda: |-
+        ESP_LOGI("main", "Tag removed: %s", x.c_str());


### PR DESCRIPTION
Closes #39 (parts 1 and 2 — the unified auto-detect namespace in part 3 is left as a follow-up).

## Summary

- **Cross-encoding IC_IDENTITY probe.** When a driver's own `read_register(IC_IDENTITY)` fails to return a valid chip signature, it re-reads register `0x3F` using the sibling chip family's SPI encoding. If the sibling encoding returns a known signature, the log emits targeted "wrong driver" guidance telling the user exactly which `external_components` and top-level YAML key to switch to — instead of the current generic `IC identity mismatch` error.
- **`examples/example-st25r300.yaml`** added, covering ST25R300-specific config (no `ant_tune_a/b`, includes `rf_power`, `rx_gain_boost`, `nfcv_enabled`, `nfcb_enabled`).
- The two existing examples get a one-line header flagging them as ST25R3916/3916B-specific and pointing to the ST300 example, so users with ST300 silicon don't copy the wrong template.

## Encoding table (for reviewers)

| Op | ST25R3916 driver (`st25r_spi`) | ST25R300 driver (`st25r300_spi`) |
| --- | --- | --- |
| Register read | `0x40 \| reg` | `0x80 \| reg` |
| Register write | `reg` | `reg & 0x7F` |

So for `IC_IDENTITY = 0x3F`:
- 3916 driver's normal read sends `0x7F`, sibling probe sends `0xBF`
- ST300 driver's normal read sends `0xBF`, sibling probe sends `0x7F`

## Behaviour matrix

| Driver loaded | Silicon attached | Before this PR | After this PR |
| --- | --- | --- | --- |
| `st25r_spi` | ST25R3916 | works | works (unchanged) |
| `st25r300_spi` | ST25R300 | works | works (unchanged) |
| `st25r_spi` | ST25R300 | silent fail, generic mismatch log | targeted log: "switch YAML from st25r_spi to st25r300_spi" |
| `st25r300_spi` | ST25R3916 | silent fail, generic mismatch log | targeted log: "switch YAML from st25r300_spi to st25r_spi" (distinguishes 3916 vs 3916B) |
| either | chip absent/broken | generic mismatch log | generic mismatch log (unchanged — sibling probe also fails → falls through) |

## Implementation

- New base-class virtual `uint8_t probe_sibling_identity_()` on `st25r::ST25R` (default `0xFF`).
- Each SPI backend (`ST25RSpi`, `ST25R300Spi`) overrides with a raw 2-byte SPI transaction: enable, write-byte with the sibling's `0x80|0x3F` or `0x40|0x3F`, read-byte, disable.
- Both `reset_chip()` implementations call the probe in the identity-failure branch and emit targeted error logs if the sibling signature matches.

## Test plan

- [x] C++ unit tests: `make -C tests/unit run` → 20/20 pass
- [x] Python schema tests: `pytest tests/python/ -v` → 94/94 pass
- [ ] Hardware validation on ST25R300 board (intentionally loaded with wrong driver) to confirm the targeted log message fires as expected — the author will handle this on real silicon.
- [ ] Hardware validation on ST25R3916 board (intentionally loaded with wrong driver) — same.

## Out of scope

Part 3 of #39 (unified `st25r:` namespace with runtime auto-detect and pluggable SPI backend) is deferred — it's a larger design change and benefits from the detection primitive added here as a stepping stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)