### PR TITLE
fix(examples): correct external_components repo slug

### DIFF
--- a/examples/example-access-control.yaml
+++ b/examples/example-access-control.yaml
@@ -18,7 +18,7 @@ wifi:
   password: "WIFI_PASSWORD"
 
 external_components:
-  - source: github://JohnMcLear/esphome-st25r
+  - source: github://JohnMcLear/esphome_st25r
     components: [ st25r, st25r_spi, st25r_i2c ]
 
 # Enable SPI bus

--- a/examples/example-basic.yaml
+++ b/examples/example-basic.yaml
@@ -16,7 +16,7 @@ wifi:
   password: "PASSWORD"
 
 external_components:
-  - source: github://JohnMcLear/esphome-st25r
+  - source: github://JohnMcLear/esphome_st25r
     components: [ st25r, st25r_spi, st25r_i2c ]
 
 # Enable SPI bus


### PR DESCRIPTION
## Summary

- Fixes a real user-facing bug flagged by Qodo on #40: two example YAMLs referenced `github://JohnMcLear/esphome-st25r` (hyphen), but the canonical repo slug is `esphome_st25r` (underscore — see README and `git remote`).
- Anyone copy-pasting `example-basic.yaml` or `example-access-control.yaml` would hit a "component not found" error from ESPHome's `external_components` fetch, since the hyphen-form repo does not exist on GitHub.
- `example-st25r300.yaml` (added in #40) already used the correct slug; this PR brings the two older files in line.

## Test plan

- [x] `grep -rn esphome-st25r examples/ README.md` — returns no hits
- [ ] Optional: `esphome config examples/example-basic.yaml` and `examples/example-access-control.yaml` on a machine with internet access, to confirm `external_components` now resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)