### PR TITLE
test(fixtures): add ST25R300R1 hardware config pair

### DIFF
--- a/tests/test-st25r300r1-correct.yaml
+++ b/tests/test-st25r300r1-correct.yaml
@@ -1,0 +1,48 @@
+# Correct config for ST25R300R1 silicon on an ESP32-S3 with USB Serial/JTAG
+# console. Uses the st25r300_spi driver (the ST25R300 family, not the
+# ST25R3916 family — see test-wrong-driver-warning.yaml for the common
+# mistake).
+
+esphome:
+  name: st25r300r1-gamma
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG: "y"
+      CONFIG_ESP_CONSOLE_UART_DEFAULT: "n"
+      CONFIG_ESP_CONSOLE_SECONDARY_NONE: "y"
+
+logger:
+  level: DEBUG
+  hardware_uart: USB_SERIAL_JTAG
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [st25r300, st25r300_spi]
+
+spi:
+  clk_pin: GPIO10
+  miso_pin: GPIO11
+  mosi_pin: GPIO9
+
+st25r300_spi:
+  id: my_st25r300
+  cs_pin: GPIO8
+  irq_pin: GPIO13
+  reset_pin: GPIO12
+  update_interval: 2s
+  on_tag:
+    then:
+      - logger.log:
+          format: "Tag detected: %s"
+          args: ['x.c_str()']
+  on_tag_removed:
+    then:
+      - logger.log:
+          format: "Tag removed: %s"
+          args: ['x.c_str()']

--- a/tests/test-wrong-driver-warning.yaml
+++ b/tests/test-wrong-driver-warning.yaml
@@ -1,0 +1,51 @@
+# Intentionally-wrong config: loads the st25r_spi (ST25R3916) driver against
+# ST25R300R1 silicon. Used to hardware-validate the cross-encoding
+# IC_IDENTITY probe added in PR #40 — on real ST25R300 silicon this should
+# produce an ESP_LOGE "switch YAML from st25r_spi to st25r300_spi" message
+# at boot.
+#
+# For the correct ST25R300R1 config see test-st25r300r1-correct.yaml.
+
+esphome:
+  name: st25r300r1-wrong-driver
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG: "y"
+      CONFIG_ESP_CONSOLE_UART_DEFAULT: "n"
+      CONFIG_ESP_CONSOLE_SECONDARY_NONE: "y"
+
+logger:
+  level: DEBUG
+  hardware_uart: USB_SERIAL_JTAG
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [st25r, st25r_spi]
+
+spi:
+  clk_pin: GPIO10
+  miso_pin: GPIO11
+  mosi_pin: GPIO9
+
+st25r_spi:
+  id: my_st25r
+  cs_pin: GPIO8
+  irq_pin: GPIO13
+  reset_pin: GPIO12
+  update_interval: 2s
+  on_tag:
+    then:
+      - logger.log:
+          format: "Tag detected: %s"
+          args: ['x.c_str()']
+  on_tag_removed:
+    then:
+      - logger.log:
+          format: "Tag removed: %s"
+          args: ['x.c_str()']


### PR DESCRIPTION
## Summary

Adds two matched hardware-test fixtures for an ESP32-S3 + USB-JTAG board wired to ST25R300R1 silicon:

- **`tests/test-wrong-driver-warning.yaml`** — intentionally loads the wrong driver (`st25r_spi`, the ST25R3916 family) against ST25R300 silicon. Used to hardware-validate the cross-encoding \`IC_IDENTITY\` probe from #40 — on real ST25R300 silicon boot should produce an \`ESP_LOGE\` telling the user to switch YAML to \`st25r300_spi\`. Satisfies the unchecked \"intentionally loaded with wrong driver\" test-plan item on #40.
- **`tests/test-st25r300r1-correct.yaml`** — the matching correct config using \`st25r300_spi\`, same pin wiring and S3/esp-idf/USB-JTAG setup.

## Why not CI-wired

The wrong-driver diagnostic is runtime-only — it needs real silicon (or a sibling-encoding SPI simulator) to fire. A CI compile pass of the wrong YAML would succeed silently, which is the correct-by-design behaviour but adds no test signal. Hardware-flash validation is the intended use.

## Test plan

- [x] \`git status\` clean after commit
- [ ] Author flashes \`test-wrong-driver-warning.yaml\` to ST25R300R1 hardware, confirms \"switch YAML from st25r_spi to st25r300_spi\" log line appears at boot
- [ ] Author flashes \`test-st25r300r1-correct.yaml\` to same hardware, confirms normal boot with no wrong-driver warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)